### PR TITLE
Update scraper url for 2012 term

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -59,4 +59,4 @@ def scrape_person(url)
   data
 end
 
-scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&StartSearch=1&FName=&LName=&RID=1&City=-1&Cat=-1&Mem=-1&Aso=-1&Com=-1')
+scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&RID=1')

--- a/scraper.rb
+++ b/scraper.rb
@@ -59,4 +59,4 @@ def scrape_person(url)
   data
 end
 
-(0..2).each { |i| scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&First=0&Last=274&CurrentPage=%d' % i) }
+scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&StartSearch=1&FName=&LName=&RID=1&City=-1&Cat=-1&Mem=-1&Aso=-1&Com=-1')


### PR DESCRIPTION
This PR updates the url of the scraper to point to the 2012 term.

The url in the scraper was not working anymore, so it was loading
the last term page by default, but assigning the data to the previous
term through a hardcoded term field (i.e., term = 2012).
This change updates the scraper with the right url to the previous
term (2012)

## Notes to merger

This PR should be merged before #1 and #2.

## Scraper Change checklist

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group <https://morph.io/everypolitician-scrapers/syria-peoples-council/>
* [x] scraper's GitHub "Website" link points at morph.io page <https://github.com/everypolitician-scrapers/syria-peoples-council/blob/master/scraper.rb>
* [x] scraper is set to auto-run <https://morph.io/everypolitician-scrapers/syria-peoples-council/settings>
* [ ] scraper is configured for archiving _(unless source doesn't require that)_ will be in the next PR after this is merged
* [ ] ~legislature has a scraper webhook set? _(usually only set on Wikidata person-data scrapers)_~ Not needed