### PR TITLE
Update scraper url

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -59,4 +59,4 @@ def scrape_person(url)
   data
 end
 
-scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&StartSearch=1&FName=&LName=&RID=1&City=-1&Cat=-1&Mem=-1&Aso=-1&Com=-1')
+scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&RID=1')

--- a/scraper.rb
+++ b/scraper.rb
@@ -59,4 +59,4 @@ def scrape_person(url)
   data
 end
 
-(0..2).each { |i| scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&First=0&Last=274&CurrentPage=%d' % i) }
+scrape_list('http://parliament.gov.sy/arabic/index.php?node=210&StartSearch=1&FName=&LName=&RID=1&City=-1&Cat=-1&Mem=-1&Aso=-1&Com=-1')


### PR DESCRIPTION
The url in the scraper was not working anymore, so it was redirecting to
the last term page by default, but assigning the data to the previous term
through a hardcoded term field (i.e., term = 2012). This change updates the
scraper with the right url to the previous term (2012).